### PR TITLE
MAINT: Speed-up random_polyagamma_fill function

### DIFF
--- a/include/pgm_random.h
+++ b/include/pgm_random.h
@@ -57,14 +57,9 @@ pgm_random_polyagamma(bitgen_t* bitgen_state, double h, double z, sampler_t meth
  *      The array to place the generated samples. Only the first n elements
  *      will be populated.
  */
-PGM_INLINE void
+void
 pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
-                           sampler_t method, size_t n, double* out)
-{
-    while (n--) {
-        out[n] = pgm_random_polyagamma(bitgen_state, h, z, method);
-    }
-}
+                           sampler_t method, size_t n, double* out);
 
 /*
  * Generate n samples from a PG(h[i], z[i]) distribution, where h and z are
@@ -73,14 +68,8 @@ pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
  * h, z and out must be at least `n` in length. Only the first n elements of
  * `out` will be filled.
  */
-PGM_INLINE void
-pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h,
-                            const double* z, sampler_t method, size_t n,
-                            double* restrict out)
-{
-    while (n--) {
-        out[n] = pgm_random_polyagamma(bitgen_state, h[n], z[n], method);
-    }
-}
+void
+pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h, const double* z,
+                            sampler_t method, size_t n, double* restrict out);
 
 #endif

--- a/src/pgm_alternate.h
+++ b/src/pgm_alternate.h
@@ -1,8 +1,11 @@
 #ifndef PGM_ALTERNATE_H
 #define PGM_ALTERNATE_H
+#include <stddef.h>
 
 typedef struct bitgen bitgen_t;
 
-double random_polyagamma_alternate(bitgen_t* bitgen_state, double h, double z);
+void
+random_polyagamma_alternate(bitgen_t* bitgen_state, double h, double z,
+                            size_t n, double* out);
 
 #endif

--- a/src/pgm_devroye.h
+++ b/src/pgm_devroye.h
@@ -1,8 +1,11 @@
 #ifndef PGM_DEVROYE_H
 #define PGM_DEVROYE_H
+#include <stddef.h>
 
 typedef struct bitgen bitgen_t;
 
-double random_polyagamma_devroye(bitgen_t *bitgen_state, double h, double z);
+void
+random_polyagamma_devroye(bitgen_t* bitgen_state, double h, double z,
+                          size_t n, double* out);
 
 #endif

--- a/src/pgm_random.c
+++ b/src/pgm_random.c
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause */
 #include <math.h>
+#include <string.h>
 #include "pgm_devroye.h"
 #include "pgm_alternate.h"
 #include "pgm_saddle.h"
@@ -13,20 +14,11 @@
     #define PGM_EXTERN
 #endif
 
-PGM_EXTERN PGM_INLINE void
-pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
-                           sampler_t method, size_t n, double* out);
-
-PGM_EXTERN PGM_INLINE void
-pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h,
-                            const double* z, sampler_t method, size_t n,
-                            double* restrict out);
-
 /* numpy c-api declarations */
 PGM_EXTERN double
-random_standard_normal(bitgen_t *bitgen_state);
+random_standard_normal(bitgen_t* bitgen_state);
 PGM_EXTERN double
-random_standard_gamma(bitgen_t *bitgen_state, double shape);
+random_standard_gamma(bitgen_t* bitgen_state, double shape);
 
 /*
  * Sample from a PG(h. z) using a Normal Approximation. For sufficiently large
@@ -38,21 +30,25 @@ random_standard_gamma(bitgen_t *bitgen_state, double shape);
  *   approaches 0. The formula can be easily generated using any online math
  *   equation calculator.
  */
-static PGM_INLINE double
-random_polyagamma_normal_approx(bitgen_t* bitgen_state, double h, double z)
+static PGM_INLINE void
+random_polyagamma_normal_approx(bitgen_t* bitgen_state, double h, double z,
+                                size_t n, double* out)
 {
-    double x, mean, variance;
+    double x, mean, stdev;
 
     if (z == 0.) {
         mean = 0.25 * h;
-        variance = 0.041666688 * h;
+        stdev = sqrt(0.041666688 * h);
     }
     else {
         x = tanh(0.5 * z);
         mean = 0.5 * h * x / z;
-        variance = 0.25 * h * (sinh(z) - z) * (1. - x * x) / (z * z * z);
+        stdev = sqrt(0.25 * h * (sinh(z) - z) * (1. - x * x) / (z * z * z));
     }
-    return mean + random_standard_normal(bitgen_state) * sqrt(variance);
+
+    while (n--) {
+        out[n] = mean + random_standard_normal(bitgen_state) * stdev;
+    }
 }
 
 #ifndef PGM_GAMMA_LIMIT
@@ -63,17 +59,24 @@ random_polyagamma_normal_approx(bitgen_t* bitgen_state, double h, double z)
  *
  * The infinite sum is truncated to 200 terms.
  */
-static PGM_INLINE double
-random_polyagamma_gamma_conv(bitgen_t* bitgen_state, double h, double z)
+static PGM_INLINE void
+random_polyagamma_gamma_conv(bitgen_t* bitgen_state, double h, double z,
+                             size_t n, double* out)
 {
     z = 0.5 * fabs(z);
     static const double pi2 = 9.869604401089358;
-    double out = 0., n = 0.5, z2 = z * z;
+    double z2 = z * z;
 
-    do {
-        out += random_standard_gamma(bitgen_state, h) / (pi2 * n * n + z2);
-    } while (++n < PGM_GAMMA_LIMIT);
-    return 0.5 * out;
+    memset(out, 0, n * sizeof(*out));
+
+    while(n--) {
+        double m = 0.5;
+        do {
+            out[n] += random_standard_gamma(bitgen_state, h) / (pi2 * m * m + z2);
+        } while (++m < PGM_GAMMA_LIMIT);
+
+        out[n] *= 0.5;
+    }
 }
 
 /*
@@ -82,25 +85,27 @@ random_polyagamma_gamma_conv(bitgen_t* bitgen_state, double h, double z)
  *
  * Refer to README.md file for more details.
  */
-static PGM_INLINE double
-random_polyagamma_hybrid(bitgen_t* bitgen_state, double h, double z)
+static PGM_INLINE void
+random_polyagamma_hybrid(bitgen_t* bitgen_state, double h, double z,
+                         size_t n, double* out)
 {
     if (h > 50.) {
-        return random_polyagamma_normal_approx(bitgen_state, h, z);
+        random_polyagamma_normal_approx(bitgen_state, h, z, n, out);
     }
     else if (h >= 25. || (((h > 12. && h == (size_t)h) || h >= 8.) && z < 2.)) {
-        return random_polyagamma_saddle(bitgen_state, h, z);
+        random_polyagamma_saddle(bitgen_state, h, z, n, out);
     }
     else if (h == 1. || (h == (size_t)h && z < 2.)) {
-        return random_polyagamma_devroye(bitgen_state, h, z);
+        random_polyagamma_devroye(bitgen_state, h, z, n, out);
     }
     else {
-       return random_polyagamma_alternate(bitgen_state, h, z);
+       random_polyagamma_alternate(bitgen_state, h, z, n, out);
     }
 }
 
 
-typedef double (*pgm_func_t)(bitgen_t* bitgen_state, double h, double z);
+typedef void
+(*pgm_func_t)(bitgen_t* bitgen_state, double h, double z, size_t n, double* out);
 
 const pgm_func_t sampling_method_table[] = {
     [ALTERNATE] = random_polyagamma_alternate,
@@ -114,5 +119,28 @@ const pgm_func_t sampling_method_table[] = {
 PGM_INLINE double
 pgm_random_polyagamma(bitgen_t* bitgen_state, double h, double z, sampler_t method)
 {
-    return sampling_method_table[method](bitgen_state, h, z);
+    double out;
+
+    sampling_method_table[method](bitgen_state, h, z, 1, &out);
+    return out;
+}
+
+
+PGM_INLINE void
+pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
+                           sampler_t method, size_t n, double* out)
+{
+    sampling_method_table[method](bitgen_state, h, z, n, out);
+}
+
+
+PGM_INLINE void
+pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h, const double* z,
+                            sampler_t method, size_t n, double* restrict out)
+{
+    pgm_func_t f = sampling_method_table[method];
+
+    while (n--) {
+        f(bitgen_state, h[n], z[n], 1, out + n);
+    }
 }

--- a/src/pgm_saddle.h
+++ b/src/pgm_saddle.h
@@ -1,8 +1,11 @@
 #ifndef PGM_SADDLE_H
 #define PGM_SADDLE_H
+#include <stddef.h>
 
 typedef struct bitgen bitgen_t;
 
-double random_polyagamma_saddle(bitgen_t* bitgen_state, double h, double z);
+void
+random_polyagamma_saddle(bitgen_t* bitgen_state, double h, double z,
+                         size_t n, double* out);
 
 #endif


### PR DESCRIPTION
closes #74

To avoid code duplication, I decided in making sure all concrete implementations of the sampling methods accept a size and pointer parameter. After experimentation this turned out to be the most sensible approach given the constraints. As far as speed improvements, it turns out this was a success.

Main branch timings:
```ipynb
In [1]: from polyagamma import random_polyagamma

In [2]: import numpy as np

In [3]: rng = np.random.default_rng(1)

In [4]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='devroye')
50.8 ms ± 704 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [5]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='alternate')
26 ms ± 710 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [6]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='saddle')
29.9 ms ± 519 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='gamma')
173 ms ± 2.57 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```
This branch's timings:
```ipynb
In [1]: from polyagamma import random_polyagamma

In [2]: import numpy as np

In [3]: rng = np.random.default_rng(1)

In [4]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='devroye')
48.3 ms ± 32.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [5]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='alternate')
13.9 ms ± 24.9 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [6]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='saddle')
8.97 ms ± 55.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [7]: %timeit random_polyagamma(20, 5, random_state=rng, size=20000, method='gamma')
159 ms ± 196 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

```

`devroye`: 4.92% boost
`alternate`: 87% boost
`saddle`: 233% boost
`gamma`: 8.8% boost

The speed boost using the default parameter values (`h=1`, `z=0`) are:

`devroye`: 8.67% boost
`alternate`: 50% boost
`saddle`: 159% boost
`gamma`: 0% boost