### PR TITLE
BUG: make sure parameter validation does not fail for numpy arrays of float when method="devroye".

### DIFF
--- a/polyagamma/_polyagamma.pyx
+++ b/polyagamma/_polyagamma.pyx
@@ -79,7 +79,7 @@ cdef inline int check_method(object h, str method, bint disable_checks,
         if is_a_number(h):
             raise_error = PyObject_RichCompareBool(PyNumber_Long(h), h, Py_NE)
         else:
-            o = np.PyArray_FROM_OT(h, np.NPY_LONG) != np.PyArray_FROM_O(h)
+            o = np.PyArray_FROM_OTF(h, np.NPY_LONG, np.NPY_ARRAY_FORCECAST) != np.PyArray_FROM_O(h)
             raise_error = any(np.PyArray_Ravel(o, np.NPY_CORDER))
         if raise_error:
             raise ValueError("devroye method must have integer values for h")

--- a/tests/test_polyagamma.py
+++ b/tests/test_polyagamma.py
@@ -104,6 +104,13 @@ def test_polyagamma():
     h = (1, 2, 3)
     rng_polyagamma(h, method="devroye")
     rng_polyagamma(h, method="alternate")
+    # test to see if numpy array input of whole numbers does not cause the
+    # sampler to fail when method="devroye" is set explicitly. This means that
+    # elements `2` and `2.0` get treated the same when parameter validation
+    # checks are performed for this method to ensure all h elements are integers.
+    # See GH-issue #84
+    random_polyagamma(np.ones(1), method="devroye")
+    random_polyagamma(np.array([1., 2, 3.0]), method="devroye")
 
     # raise an error when using devroye with non-integer values of h
     with pytest.raises(ValueError):


### PR DESCRIPTION
closes #84 
