### PR TITLE
ENH: Generalize size argument when h and z are not both scalars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ o = random_polyagamma()
 # Get a 5 by 10 array of PG(1, 2) variates.
 o = random_polyagamma(z=2, size=(5, 10))
 
-# Pass sequences as input. Numpy's broadcasting rules apply here.
+# We can pass sequences as input. Numpy's broadcasting rules apply here.
+# Get a 10 by 2 array where column 1 is PG(2, -10) and column 2 is PG(1, 10)
+o = random_polyagamma([2, 1], [-10, 10], size=(10, 2))
 z = [[1.5, 2, -0.75, 4, 5],
      [9.5, -8, 7, 6, -0.9]]
 o = random_polyagamma(1, z)

--- a/tests/test_polyagamma.py
+++ b/tests/test_polyagamma.py
@@ -17,9 +17,11 @@ def test_polyagamma():
 
     assert len(rng_polyagamma(size=5)) == 5
     assert rng_polyagamma(size=(5, 2)).shape == (5, 2)
-    # test if non-integer elements of size get truncated to ints
-    assert rng_polyagamma(size=(5.1, 2.9)).shape == (5, 2)
-    assert rng_polyagamma(size=10.4).shape == (10,)
+    # test if non-integer elements of size raise exception
+    with pytest.raises(ValueError, match="`size` is not a valid argument"):
+        assert rng_polyagamma(size=(5.1, 2.9))
+    with pytest.raises(ValueError, match="`size` is not a valid argument"):
+        assert rng_polyagamma(size=10.4)
 
     h = [[[0.59103028], [0.15228518], [0.53494081], [0.85875483], [0.05796053]],
          [[0.63934113], [0.1341983 ], [0.73854957], [0.76351291], [0.38431413]],
@@ -31,6 +33,16 @@ def test_polyagamma():
     z = np.array([1, 2, 3, 4, 6])
     assert rng_polyagamma(h, z).shape == (4, 5, 5)
     assert rng_polyagamma(h, 0.12345).shape == (4, 5, 1)
+
+    # test output of passing `size` when h and z are not both scalars
+    assert rng_polyagamma(z, size=(10, 1, 5)).shape == (10, 1, 5)
+    assert rng_polyagamma(h, z, size=(2, 4, 5, 5)).shape == (2, 4, 5, 5)
+    with pytest.raises(ValueError, match="array is not broadcastable"):
+        rng_polyagamma(z, size=(10, 1, 4))
+    # test if the expected exception is returned when `size` is the wrong object
+    with pytest.raises(ValueError, match="`size` is not a valid argument"):
+        rng_polyagamma(z, size={10, 1, 4})
+
 
     # should work on list/tuple input
     h = [[1000, 2, 3], [3, 3, 1]]


### PR DESCRIPTION
closes #89 

```python
In [1]: from polyagamma import random_polyagamma
In [2]: random_polyagamma([2, 3], size=(4, 3, 2))
Out[2]: 
array([[[0.3098445 , 0.43956714],
        [0.25167463, 0.50533742],
        [0.63885505, 0.89972251]],

       [[0.35694466, 0.27654623],
        [0.41971661, 0.7791482 ],
        [0.844241  , 0.93211144]],

       [[0.16514916, 0.66957613],
        [0.94953758, 0.80876849],
        [0.58656499, 0.46201302]],

       [[0.23648597, 0.62121602],
        [0.2076209 , 1.16718034],
        [0.53185656, 0.59082658]]])

```