### PR TITLE
BLD: Add support for python 3.10 and drop python 3.6 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
+        python-version: [ '3.7' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache/restore poetry lockfile
         uses: actions/cache@v2
@@ -33,7 +34,7 @@ jobs:
 
       - name: Install Dependencies and Cythonize extension
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel poetry
+          python3 -m pip install --upgrade pip setuptools wheel poetry cibuildwheel==2.4.0
           poetry install --no-root
           poetry run cythonize polyagamma/*.pyx
 
@@ -46,14 +47,14 @@ jobs:
 
       - name: Build wheels
         env:
+          # skip pypy builds
+          CIBW_SKIP: "pp* *-musllinux_x86_64 cp36-* cp38-win* cp39-win* cp310-win* cp310-manylinux* cp39-macosx* cp310-macosx*"
           CIBW_ARCHS_LINUX: "auto64"
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_ARCHS_WINDOWS: "auto64"
-          CIBW_TEST_COMMAND: 'python -c "from polyagamma import random_polyagamma; print(random_polyagamma());"'
+          CIBW_TEST_COMMAND: 'python -c "import polyagamma; print(polyagamma.random_polyagamma());"'
           BUILD_WHEEL: true
-          # skip pypy builds
-          CIBW_SKIP: pp*
-        uses: pypa/cibuildwheel@v2.4.0
+        run: poetry run cibuildwheel --output-dir wheelhouse
 
       - name: Build source distribution
         if: ${{ matrix.os == 'ubuntu-20.04' }}


### PR DESCRIPTION
The updates to cibuildwheel package resulted in a lot of failed wheel
builds. The support for python 3.10 is not yet rubust. Several other
versions of python on multiple platforms are now failing to build
wheels. Thus the following wheels have been disabled for now:
* 3.8, 3.9 and 3.10 on windows
* 3.9 and 3.10 on MacOS
* 3.10 on Linux