### PR TITLE
REL: Prepare for v1.3.6 release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-tags: 'true'
+          fetch-depth: 0
 
       - name: Set up QEMU
         if: runner.os == 'Linux'

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 clean:
 	rm -Rf build/* dist/* polyagamma/*.c polyagamma/*.so polyagamma/*.html \
 		./**/polyagamma.egg-info **/*__pycache__ __pycache__ .coverage* \
+		polyagamma/_version.py \
 
 cythonize:
 	cythonize polyagamma/*.pyx

--- a/polyagamma/__init__.py
+++ b/polyagamma/__init__.py
@@ -1,4 +1,11 @@
 from ._polyagamma import (
     polyagamma as random_polyagamma, polyagamma_pdf, polyagamma_cdf
 )
-from ._version import version as __version__, version_tuple as __version_info__
+try:
+    from ._version import __version__, __version_tuple__
+except ImportError:  # pragma: no cover
+    raise RuntimeError(
+        "Unable to find the version number that is generated when either building or "
+        "installing from source. Please make sure that `polyagamma` has been properly "
+        "installed, e.g. with\n\n  pip install -e .\n"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ packages = ["polyagamma"]
 polyagamma = ["*.pyx"]
 
 [tool.setuptools_scm]
-write_to = "polyagamma/_version.py"
+version_file = "polyagamma/_version.py"
 
 [tool.coverage.run]
 plugins = ["Cython.Coverage"]
@@ -73,6 +73,7 @@ before-test = "pip install numpy --pre"
 test-command = [
     "python -c 'from polyagamma import random_polyagamma;print(random_polyagamma());'"
 ]
+environment = { SETUPTOOLS_SCM_DEBUG = 1 }
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
`actions/checkout` introduced a breaking change where the github action does no longer fetches tags by default. We add extra parameters to the action to ensure tags are fetched so that the correct version number of the package can be inferred by `setuptools-scm`.