### PR TITLE
BUILD: Remove cython as hard build dependency.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           platforms: all
 
+      - name: Cythonize C-extensions
+        run: |
+          python3 -m pip install --upgrade pip cython==0.29.*
+          cythonize polyagamma/*.pyx
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:
@@ -48,7 +53,9 @@ jobs:
       - name: Build source distribution
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
-          python -m pip install --upgrade pip build
+          python3 -m pip install --upgrade pip cython==0.29.* build
+          cythonize polyagamma/*.pyx
+          python -m pip install build
           python -m build --sdist
           mv dist/*.gz wheelhouse
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ prune .github
 prune examples
 prune scripts
 prune tests
+exclude Makefile
+exclude polyagamma/*.pyx requirements-dev.txt .pre-commit-config.yaml .gitignore

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,17 @@ cythonize:
 
 dev:
 	pip install -r requirements-dev.txt
+	cythonize polyagamma/*.pyx
+	pip install -e .
 	pre-commit install --install-hooks
 
-sdist:
+sdist: dev
 	python -m build --sdist
 
-wheel:
+wheel: dev
 	python -m build --wheel
 
-test: cythonize
+test: dev
 	pytest tests/ -vvv
 
 test-cov: clean

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For an example of how to use `polyagamma` in a C program, see [here][1].
 
 
 ## Installation
-To get the latest version of the package, one can install it by downloading the wheel/source distribution 
+To get the latest version of the package, one can install it by downloading the wheel/source distribution
 from the [releases][3] page, or using `pip` with the following shell command:
 ```shell
 $ pip install --pre -U polyagamma
@@ -169,14 +169,16 @@ Alternatively, once can install from source with the following shell commands:
 ```shell
 $ git clone https://github.com/zoj613/polyagamma.git
 $ cd polyagamma/
+$ pip install cython==0.29.*
+$ cythonize polyagamma/*.pyx
 $ pip install .
 ```
 
 
 ## Benchmarks
 
-Below are runtime plots of 20000 samples generated for various values of `h` 
-and `z`, using each method. We restrict `h` to integer values to accomodate the 
+Below are runtime plots of 20000 samples generated for various values of `h`
+and `z`, using each method. We restrict `h` to integer values to accomodate the
 `devroye` method, which cannot be used for non-integer `h`. The version of the
 package used to generate them is `v1.3.1`.
 
@@ -191,13 +193,13 @@ Generally:
 - For `h >= 8`, the `saddle` method is the fastest for any value of `z`.
 - For `0 <= z <= 1` and integer `h <= 4`, the `devroye` method should be preferred.
 - For `z > 1` and `1 < h < 8`, the `alternate` method is the most efficient.
-- For `h > 50` (or any value large enough), the normal approximation to the distribution is 
-fastest (not reported in the above plot but it is around 10 times faster than the `saddle` 
+- For `h > 50` (or any value large enough), the normal approximation to the distribution is
+fastest (not reported in the above plot but it is around 10 times faster than the `saddle`
 method and also equally accurate).
 
 Therefore, we devise a "hybrid/default" sampler that picks a sampler based on the above guidelines.
 
-We also benchmark the hybrid sampler runtime with the sampler found in the `pypolyagamma` 
+We also benchmark the hybrid sampler runtime with the sampler found in the `pypolyagamma`
 package (version `1.2.3`). The version of NumPy we use is `1.19.0`. We compare our
 sampler to the `pgdrawv` functions provided by the package. Below are runtime plots of 20000
 samples for each value of `h` and `z`. Values of `h` range from 0.1 to 50, while `z` is set
@@ -209,7 +211,7 @@ to 0, 2.5, 5, and 10.
 |![](./scripts/img/perf_samplers_5.0.svg) | ![](./scripts/img/perf_samplers_10.0.svg)|
 | --- | --- |
 
-It can be seen that when generating many samples at once for any given combination of 
+It can be seen that when generating many samples at once for any given combination of
 parameters, `polyagamma` outperforms the `pypolyagamma` package by a large margin.
 The exception is when the scale parameter is very small (e.g `h < 1`). It is also worth
 noting that the `pypolygamma` package is on average faster than ours at generating exactly 1
@@ -234,7 +236,7 @@ To generate the above plots locally, run
 $ pip install -r scripts/requirements.txt
 $ python scripts/benchmark.py --size=<some size> --z=<z value>
 ```
-Note that the runtimes may differ  than the ones reported here, depending on the machine this script 
+Note that the runtimes may differ  than the ones reported here, depending on the machine this script
 is ran on.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "wheel",
-    "cython==0.29.36",
     "setuptools>=61.0.0",
     "setuptools-scm",
     # Here we build the project using the earliest numpy version supported  by
@@ -52,7 +51,11 @@ tracker = "https://github.com/zoj613/polyagamma/issues"
 packages = ["polyagamma"]
 
 [tool.setuptools.exclude-package-data]
-polyagamma = ["*.pyx"]
+# these get excluded from the wheel distribution only
+polyagamma = ["*.pyx", "_polyagamma.c"]
+
+[tool.setuptools.package-data]
+polyagamma = ["_polyagamma.c"]
 
 [tool.setuptools_scm]
 version_file = "polyagamma/_version.py"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--e .
 cython==0.29.36
 numpy==1.26.0
 pre-commit==3.4.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 source_files = [
-    "polyagamma/_polyagamma.pyx",
+    "polyagamma/_polyagamma.c",
     "src/pgm_random.c",
     "src/pgm_alternate.c",
     "src/pgm_devroye.c",


### PR DESCRIPTION
To avoid issues with cython installation downstream (e.g when building conda packagees using the source distribution), we follow the recommendations outlined in the [cython docs](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules) and not require cython as a build dependency by cythonizing the c-extension files prior to distributing the package. This approach simplifies the installation via the source distribution at the user level and makes maintaining the conda package less painful.