### PR TITLE
BUILD,CI: Use latest numpy version to build wheels.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-12, windows-2019 ]
+        os: [ ubuntu-20.04, macOS-13, windows-2019 ]
         python-version: [ '3.10', 'pypy3.10', '3.11', '3.12', '3.13' ]
       fail-fast: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-12, windows-2019 ]
+        os: [ ubuntu-20.04, macOS-13, windows-2019 ]
       fail-fast: false
 
     steps:
@@ -35,20 +35,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Cythonize C-extensions
         run: |
-          python3 -m pip install --upgrade pip cibuildwheel==2.19.2
+          python3 -m pip install --upgrade pip cibuildwheel
           python3 -m pip install -r requirements-dev.txt
           cythonize polyagamma/*.pyx
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "pyproject.toml"
+        run: python -m cibuildwheel --output-dir wheelhouse --config-file pyproject.toml
 
       - name: Build source distribution
         if: ${{ matrix.os == 'ubuntu-20.04' }}
@@ -60,11 +56,12 @@ jobs:
           mv dist/*.gz wheelhouse
 
       - name: Store the wheelhouse directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_and_sdist
+          name: wheels_and_sdist-${{ matrix.os }}
           path: wheelhouse
           if-no-files-found: error
+          overwrite: true
 
   upload_pypi:
     needs: [ build_wheels_and_sdist ]
@@ -76,12 +73,16 @@ jobs:
       id-token: write
     steps:
       - name: Pull built wheels and sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: wheels_and_sdist
           path: wheelhouse
+          pattern: wheels_and_sdist-*
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: ls -R wheelhouse
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: wheelhouse

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Alternatively, one can install from source with the following shell commands:
 ```shell
 $ git clone https://github.com/zoj613/polyagamma.git
 $ cd polyagamma/
-$ pip install cython==0.29.*
+$ pip install cython==3.0.*
 $ cythonize polyagamma/*.pyx
 $ pip install .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = [
     "wheel",
     "setuptools>=61.0.0",
     "setuptools-scm",
-    "numpy==2.1.3; python_version>='3.10' and platform_python_implementation!='PyPy'",
+    "numpy>=2.2.4; python_version>='3.10' and platform_python_implementation!='PyPy'",
     # PyPy specific requirements
-    "numpy==2.1.3; python_version=='3.10' and platform_python_implementation=='PyPy'",
+    "numpy>=2.2.4; python_version=='3.10' and platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -64,9 +64,8 @@ archs = ["auto64"]
 # We also skip musllinux wheels for the aarch64 architecture because building a wheel takes hours.
 skip = ["pp31*", "pp3*_aarch64", "*-musllinux_aarch64"]
 # The test-command string is not parsed correctly on windows so we skip testing the wheel for now.
-# ARM64 wheels on MacOS currently can't be test with cibuildwheels, so we skip testing until it can be supoorted.
-test-skip = ["*-win*", "*-macosx_arm64"]
-before-test = "pip install numpy --pre"
+test-skip = ["*-win*"]
+before-test = "pip install numpy"
 test-command = [
     "python -c 'from polyagamma import random_polyagamma;print(random_polyagamma());'"
 ]
@@ -76,7 +75,10 @@ environment = { SETUPTOOLS_SCM_DEBUG = 1 }
 archs = ["x86_64", "aarch64"]
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+# We skip building of ARM64 wheels because they can't be tested in the CI
+# and we follow recommendations of the cibuildwheel team by having users build
+# them natively at install time of this package via `pip install polyagamma`.
+archs = ["x86_64"]
 
 [[tool.cibuildwheel.overrides]]
 # To avoid errors building numpy for the musllinux linux wheels, we install blas.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-cython==3.0.11
-numpy==2.1.3
-pre-commit==4.0.1
-pytest==8.3.3
+cython==3.0.12
+numpy==2.2.4
+pre-commit==4.1.0
+pytest==8.3.5
 pytest-cov==6.0.0
-setuptools==75.3.0
+setuptools==75.8.2


### PR DESCRIPTION
This ensures we use the latest available numpy version to build wheels. We also no longer build the wheels on ARM64 arch of MacOS since they are built on the x86_64 arch and thus cannot be tested on the CI release pipeline. As recommended by the CIBUILDWHEEL team, we have users build the ARM64 wheels on MacOS natively during installation of the package via source distribution. Both the above address the bug reported in https://github.com/zoj613/polyagamma/issues/129, since the bug originates from numpy's 2.1.3 version used to build wheels of version 2.0.1.

closes #129 