### PR TITLE
MAINT: Use numpy's Cython declarations for Iterator API.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-13, windows-2019 ]
+        os: [ ubuntu-22.04, macOS-13, windows-2019 ]
         python-version: [ '3.10', 'pypy3.10', '3.11', '3.12', '3.13' ]
       fail-fast: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-13, windows-2019 ]
+        os: [ ubuntu-22.04, macOS-13, windows-2019 ]
       fail-fast: false
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ requires = [
     "wheel",
     "setuptools>=61.0.0",
     "setuptools-scm",
-    "numpy>=2.2.4; python_version>='3.10' and platform_python_implementation!='PyPy'",
+    # See https://github.com/numpy/numpy/pull/28453 for reasons why we need at least numpy v2.2.5 at build-time
+    "numpy>=2.2.5; python_version>='3.10' and platform_python_implementation!='PyPy'",
     # PyPy specific requirements
-    "numpy>=2.2.4; python_version=='3.10' and platform_python_implementation=='PyPy'",
+    "numpy>=2.2.5; python_version=='3.10' and platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 cython==3.0.12
-numpy==2.2.4
-pre-commit==4.1.0
+numpy==2.2.5
+pre-commit==4.2.0
 pytest==8.3.5
-pytest-cov==6.0.0
-setuptools==75.8.2
+pytest-cov==6.1.1
+setuptools==78.1.1


### PR DESCRIPTION
Since numpy v2.0.0, the Iterator API is part of cython declarions. See the PR adding this feature: https://github.com/numpy/numpy/pull/24691 . This means we do not need to manually import these declarations.